### PR TITLE
Support RN 0.40 headers while retaining backwards compatibility.

### DIFF
--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -8,7 +8,13 @@
  */
 
 #import "AppDelegate.h"
+#if __has_include(<React/RCTRootView.h>)
+// React Native >= 0.40
+#import <React/RCTRootView.h>
+#else
+// React Native <= 0.39
 #import "RCTRootView.h"
+#endif
 
 @implementation AppDelegate
 

--- a/example/ios/exampleTests/exampleTests.m
+++ b/example/ios/exampleTests/exampleTests.m
@@ -10,8 +10,15 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "RCTLog.h"
+#if __has_include(<React/RCTRootView.h>)
+// React Native >= 0.40
+#import <React/RCTRootView.h>
+#import <React/RCTLog.h>
+#else
+// React Native <= 0.39
 #import "RCTRootView.h"
+#import "RCTLog.h"
+#endif
 
 #define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"

--- a/ios/RNInvoke/MethodInvocation.h
+++ b/ios/RNInvoke/MethodInvocation.h
@@ -7,7 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#if __has_include(<React/RCTBridge.h>)
+// React Native >= 0.40
+#import <React/RCTBridge.h>
+#else
+// React Native <= 0.39
 #import "RCTBridge.h"
+#endif
 
 @interface MethodInvocation : NSObject
 

--- a/ios/RNInvoke/MethodInvocation.m
+++ b/ios/RNInvoke/MethodInvocation.m
@@ -7,7 +7,13 @@
 //
 
 #import "MethodInvocation.h"
+#if __has_include(<React/RCTUIManager.h>)
+// React Native >= 0.40
+#import <React/RCTUIManager.h>
+#else
+// React Native <= 0.39
 #import "RCTUIManager.h"
+#endif
 
 static RCTBridge *_bridge;
 
@@ -167,7 +173,7 @@ static RCTBridge *_bridge;
 + (id) invoke:(NSDictionary*)params withBridge:(RCTBridge*)bridge onError:(void (^)(NSString*))onError
 {
     _bridge = bridge;
-    
+
     id target = [MethodInvocation getTarget:[params objectForKey:@"target"] onError:onError];
     if (target == nil)
     {

--- a/ios/RNInvoke/RNInvokeManager.h
+++ b/ios/RNInvoke/RNInvokeManager.h
@@ -6,7 +6,13 @@
 //  Copyright © 2016 Wix. All rights reserved.
 //
 
+#if __has_include(<React/RCTBridgeModule.h>)
+// React Native >= 0.40
+#import <React/RCTBridgeModule.h>
+#else
+// React Native <= 0.39
 #import "RCTBridgeModule.h"
+#endif
 
 @interface RNInvokeManager : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Use #if to conditionally import React headers.